### PR TITLE
Add Equinor SSO as login option

### DIFF
--- a/studio/config/@sanity/default-login.json
+++ b/studio/config/@sanity/default-login.json
@@ -2,6 +2,13 @@
   "providers": {
     "mode": "append",
     "redirectOnSingle": false,
-    "entries": []
+    "entries": [
+      {
+        "name": "saml",
+        "title": "Equinor SSO",
+        "url": "https://api.sanity.io/v2021-10-01/auth/saml/login/55ba173c",
+        "logo": "static/favicon.ico"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This will add Equinor SSO as login Option
If everything works well, we can use mode: replace instead