### PR TITLE
:sparkles: Disable news for specific datasets #651

### DIFF
--- a/web/common/helpers/datasetHelpers.ts
+++ b/web/common/helpers/datasetHelpers.ts
@@ -1,0 +1,9 @@
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET
+
+export const getDataset = () => dataset
+
+export const isGlobal = dataset === 'production'
+
+export const hasNews = dataset === 'production' || dataset === 'germany'
+
+export const hasArchivedNews = dataset === 'production'

--- a/web/pages/news/[slug].tsx
+++ b/web/pages/news/[slug].tsx
@@ -28,6 +28,7 @@ import { getNameFromLocale } from '../../lib/localization'
 import IFrame from '../../pageComponents/shared/IFrame'
 import { SkipNavContent } from '@reach/skip-nav'
 import { AllSlugsType } from '../../pageComponents/shared/LocalizationSwitch'
+import { hasNews } from '../../common/helpers/datasetHelpers'
 
 const { publicRuntimeConfig } = getConfig()
 
@@ -323,6 +324,8 @@ News.getLayout = (page: AppProps) => {
 }
 
 export const getStaticProps: GetStaticProps = async ({ params, preview = false, locale = 'en' }) => {
+  if (!hasNews) return { notFound: true }
+
   const { news, latestNews } = await getClient(preview).fetch(newsQuery, {
     slug: params?.slug,
     lang: getNameFromLocale(locale),

--- a/web/pages/news/archive/[...pagePath].tsx
+++ b/web/pages/news/archive/[...pagePath].tsx
@@ -21,6 +21,7 @@ import { anchorClick } from '../../../common/helpers/staticPageHelpers'
 import Head from 'next/head'
 import { SkipNavContent } from '@reach/skip-nav'
 import { newsSlugs } from './index'
+import { hasArchivedNews } from '../../../common/helpers/datasetHelpers'
 
 const { publicRuntimeConfig } = getConfig()
 
@@ -136,6 +137,8 @@ OldArchivedNewsPage.getLayout = (page: AppProps) => {
 }
 
 export const getStaticProps: GetStaticProps = async ({ preview = false, params, locale }) => {
+  if (!hasArchivedNews) return { notFound: true }
+
   const pagePathArray = params?.pagePath as string[]
   const pagePath = pagePathArray.join('/')
   const archiveSeverURL = publicRuntimeConfig.archiveStorageURL


### PR DESCRIPTION
If any satellite website will contain _/news_, we also need to modify the newsSlug logic to support different languages since it is now being hardcoded.