### PR TITLE
Add implicit signin to Equinor SSO

### DIFF
--- a/studio/config/@sanity/default-login.json
+++ b/studio/config/@sanity/default-login.json
@@ -1,7 +1,7 @@
 {
   "providers": {
-    "mode": "append",
-    "redirectOnSingle": false,
+    "mode": "replace",
+    "redirectOnSingle": true,
     "entries": [
       {
         "name": "saml",


### PR DESCRIPTION
With this change Equinor SSO is the only accepted login option for
Sanity Studio