### PR TITLE
⚡️Lazy load iframe embeds #1593

### DIFF
--- a/web/pageComponents/shared/iframe/IFrame.tsx
+++ b/web/pageComponents/shared/iframe/IFrame.tsx
@@ -54,7 +54,7 @@ const IFrame = ({
   if (isPreview) {
     return (
       <IFrameContainer aspectRatioPadding={containerPadding}>
-        <StyledIFrame allowFullScreen src={url} title={frameTitle} />
+        <StyledIFrame allowFullScreen loading="lazy" src={url} title={frameTitle} />
       </IFrameContainer>
     )
   }
@@ -63,7 +63,13 @@ const IFrame = ({
     <>
       <div className={`cookieconsent-optin-${cookiePolicy}`}>
         <IFrameContainer aspectRatioPadding={containerPadding}>
-          <StyledIFrame allowFullScreen src={url} title={frameTitle} data-cookieconsent={cookiePolicy}></StyledIFrame>
+          <StyledIFrame
+            allowFullScreen
+            src={url}
+            title={frameTitle}
+            loading="lazy"
+            data-cookieconsent={cookiePolicy}
+          ></StyledIFrame>
         </IFrameContainer>
       </div>
       {cookiePolicy !== 'none' && (


### PR DESCRIPTION
I ended up in an lazy load rabbit hole and these things were my findings: 
-  easiest solution (the one i pushed), which is just adding a loading=lazy directly on the iframe component
- [facades](https://developer.chrome.com/docs/lighthouse/performance/third-party-facades/), one could also use facades, but then we need to use a third party solution, and the ones chrome recommend has not been updated in a while and is not super-widely used. 
We could also use this https://www.npmjs.com/package/react-lite-youtube-embed. (also facade) Just generally sceptical using a third party solution due to sudden lack of maintenance and then we need to find another solution. 