### PR TITLE
H3 text option displays as paragraph text #2061

### DIFF
--- a/web/pageComponents/shared/portableText/components/h3Heading.tsx
+++ b/web/pageComponents/shared/portableText/components/h3Heading.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { Heading } from '@components'
 
 const StyledHeading = styled(Heading)`
-  font-weight: var(--fontWeight-bolder);
+  font-weight: var(--fontWeight-regular);
   line-height: var(--lineHeight-3);
   margin-bottom: 0.5em;
 
@@ -13,7 +13,7 @@ const StyledHeading = styled(Heading)`
 
 export const h3Heading = ({ children }: { children?: React.ReactNode }) => {
   return (
-    <StyledHeading level="h3" size="sm">
+    <StyledHeading level="h3" size="lg">
       {children}
     </StyledHeading>
   )


### PR DESCRIPTION
h3Heading is used in eventtext, ingresstext, newstext and richtext, the main difference is that h3 gets the correct size and the fontweight is default of regular and not bold as requested. 