### PR TITLE
:art: Improve performance #1059

### DIFF
--- a/sanityv3/schemas/documents/route.tsx
+++ b/sanityv3/schemas/documents/route.tsx
@@ -118,6 +118,13 @@ export default (isoCode: string, title: string) => {
         type: 'excludeFromSearch',
         name: 'excludeFromSearch',
       },
+      {
+        type: 'boolean',
+        name: 'includeInBuild',
+        title: 'Include in static build',
+        description: 'Enable this if this route should be generated at build time',
+        initialValue: false,
+      },
     ],
     preview: {
       select: {

--- a/sanityv3/schemas/documents/routeHomepage.tsx
+++ b/sanityv3/schemas/documents/routeHomepage.tsx
@@ -34,7 +34,13 @@ export default (isoCode: string, title: string) => ({
       readOnly: true,
       initialValue: { current: '/', _type: 'slug' },
     },
+    {
+      name: 'includeInBuild',
+      type: 'boolean',
+      initialValue: true,
+    },
   ],
+
   preview: {
     select: {
       title: 'content.title',

--- a/web/common/helpers/getPaths.ts
+++ b/web/common/helpers/getPaths.ts
@@ -40,7 +40,6 @@ const getTopicRoutesForLocaleToStaticallyBuild = async (locale: string) => {
       blacklist,
     },
   )
-  console.log('data', data)
   return data
 }
 

--- a/web/components/src/Link/ButtonLink.tsx
+++ b/web/components/src/Link/ButtonLink.tsx
@@ -29,7 +29,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(functio
   ref,
 ) {
   return (
-    <NextLink href={href} locale={locale}>
+    <NextLink href={href} locale={locale} prefetch={false}>
       <StyledButtonLink color="secondary" variant="outlined" ref={ref} {...rest}>
         {children}
       </StyledButtonLink>

--- a/web/components/src/Link/Link.tsx
+++ b/web/components/src/Link/Link.tsx
@@ -140,6 +140,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
         } as CSSProperties
       }
       $textDecoration={underline ? 'underline' : 'none'}
+      prefetch={false}
       {...rest}
     >
       {children} {type === 'externalUrl' ? <Icon data={external_link} size={16} /> : null}

--- a/web/components/src/Link/Link.tsx
+++ b/web/components/src/Link/Link.tsx
@@ -117,13 +117,13 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
 ) {
   if (variant === 'contentLink') {
     return (
-      <ContentLink href={href} ref={ref} {...rest}>
+      <ContentLink href={href} prefetch={false} ref={ref} {...rest}>
         {children} <Icon data={getIconData(type)} />
       </ContentLink>
     )
   } else if (variant === 'readMore') {
     return (
-      <ReadMoreLink href={href} ref={ref} {...rest}>
+      <ReadMoreLink href={href} prefetch={false} ref={ref} {...rest}>
         {children} <Icon data={getIconData(type)} />
       </ReadMoreLink>
     )

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -39,6 +39,16 @@ export default withBundle(
     experimental: {
       largePageDataBytes: 300 * 1000,
       scrollRestoration: true,
+      optimizePackageImports: [
+        '@components',
+        '@chakra-ui',
+        '@chakra-ui/skip-nav',
+        '@emotion/react',
+        '@emotion/styled',
+        '@equinor/eds-core-react',
+        '@equinor/eds-icons',
+        'hls.js',
+      ],
     },
     eslint: {
       // Warning: Dangerously allow production builds to successfully complete even if

--- a/web/pageComponents/cards/FeaturedEventCard.tsx
+++ b/web/pageComponents/cards/FeaturedEventCard.tsx
@@ -58,7 +58,7 @@ const FeaturedEventCard = ({ data, fitToContent = false, ...rest }: FeaturedEven
   const plainTitle = title ? toPlainText(title as PortableTextBlock[]) : ''
 
   return (
-    <StyledLink href={slug} {...rest}>
+    <StyledLink href={slug} {...rest} prefetch={false}>
       <StyledCard
         style={
           {

--- a/web/pageComponents/cards/MagazineCard.tsx
+++ b/web/pageComponents/cards/MagazineCard.tsx
@@ -62,7 +62,7 @@ const MagazineCard = ({ data, fitToContent = false, ...rest }: MagazineCardProp)
   if (!thumbnail) return null
 
   return (
-    <StyledLink href={slug} {...rest}>
+    <StyledLink href={slug} prefetch={false} {...rest}>
       <StyledCard
         style={
           {

--- a/web/pageComponents/cards/NewsCard.tsx
+++ b/web/pageComponents/cards/NewsCard.tsx
@@ -52,7 +52,7 @@ const NewsCard = ({ data, fitToContent = false, ...rest }: NewsCardProp) => {
   if (!heroImage) return null
 
   return (
-    <StyledLink href={slug} {...rest}>
+    <StyledLink href={slug} prefetch={false} {...rest}>
       <StyledCard
         style={
           {

--- a/web/pageComponents/cards/SimpleCard.tsx
+++ b/web/pageComponents/cards/SimpleCard.tsx
@@ -50,7 +50,7 @@ function getLink(linkData: MenuLinkData, label: string) {
 const SimpleCard = ({ data }: SimpleCardData) => {
   const { id, label, image } = data
   return (
-    <CardLink key={id} href={getLink(data, label)}>
+    <CardLink key={id} href={getLink(data, label)} prefetch={false}>
       <StyledCard
         style={
           {

--- a/web/pageComponents/cards/TopicPageCard.tsx
+++ b/web/pageComponents/cards/TopicPageCard.tsx
@@ -34,7 +34,7 @@ const TopicPageCard = ({ data, fitToContent = false, ...rest }: TopicPageCardPro
   const pageTitle = title ? toPlainText(title as PortableTextBlock[]) : ''
 
   return (
-    <StyledLink href={slug} {...rest}>
+    <StyledLink href={slug} prefetch={false} {...rest}>
       <StyledCard
         style={
           {

--- a/web/pageComponents/pageTemplates/newsroom/Hit.tsx
+++ b/web/pageComponents/pageTemplates/newsroom/Hit.tsx
@@ -47,7 +47,7 @@ const Hit = ({ hit }: { hit: any }) => {
   const pageTitle = Array.isArray(hit.pageTitle) ? toPlainText(hit.pageTitle as PortableTextBlock[]) : hit.pageTitle
 
   return (
-    <StyledHitLink href={hit.slug}>
+    <StyledHitLink href={hit.slug} prefetch={false}>
       <article>
         <Date>{hit.publishDateTime && <FormattedDate datetime={hit.publishDateTime} uppercase />}</Date>
         <StyledHeading level="h3" size="md">

--- a/web/pageComponents/search/EventHit.tsx
+++ b/web/pageComponents/search/EventHit.tsx
@@ -47,7 +47,7 @@ const EventHit = ({ hit }: HitProps) => {
   // @TODO: A more generic Hit component for more than events. Or multiple components???
   return (
     <article>
-      <StyledHitLink href={slug}>
+      <StyledHitLink href={slug} prefetch={false}>
         {eventDate && <StyledFormattedDate datetime={eventDate} uppercase></StyledFormattedDate>}
         <HitHeading level="h2" size="sm">
           <Highlight hit={hit} attribute="title" />

--- a/web/pageComponents/search/MagazineHit.tsx
+++ b/web/pageComponents/search/MagazineHit.tsx
@@ -52,7 +52,7 @@ const MagazineHit = ({ hit }: HitProps) => {
 
   return (
     <article>
-      <StyledHitLink href={slug}>
+      <StyledHitLink href={slug} prefetch={false}>
         <HitHeading level="h2" size="sm">
           <Highlight hit={hit} attribute="pageTitle" />
         </HitHeading>

--- a/web/pageComponents/search/NewsHit.tsx
+++ b/web/pageComponents/search/NewsHit.tsx
@@ -60,7 +60,7 @@ const NewsHit = ({ hit }: HitProps) => {
 
   return (
     <article>
-      <StyledHitLink href={slug}>
+      <StyledHitLink href={slug} prefetch={false}>
         {hit.publishDateTime && <StyledFormattedDate datetime={hit.publishDateTime} uppercase />}
         <HitHeading level="h2" size="sm">
           <Highlight hit={hit} attribute="pageTitle" />

--- a/web/pageComponents/search/TopicHit.tsx
+++ b/web/pageComponents/search/TopicHit.tsx
@@ -37,7 +37,7 @@ const TopicHit = ({ hit }: HitProps) => {
   // @TODO: A more generic Hit component for more than events. Or multiple components???
   return (
     <article>
-      <StyledHitLink href={slug}>
+      <StyledHitLink href={slug} prefetch={false}>
         <HitHeading level="h2" size="sm">
           <Highlight hit={hit} attribute="pageTitle" />
         </HitHeading>

--- a/web/pageComponents/shared/Footer.tsx
+++ b/web/pageComponents/shared/Footer.tsx
@@ -144,7 +144,7 @@ const Footer = forwardRef<HTMLDivElement, FooterProps>(function Footer({ footerD
                 const icon = type === 'someLink' && someType ? getSomeSvg(someType) : null
 
                 return (
-                  <FooterLink key={id} href={url || getLink(link)}>
+                  <FooterLink key={id} href={url || getLink(link)} prefetch={false}>
                     {icon && <SomeIcon aria-hidden={true}>{icon}</SomeIcon>}
                     {label}
                   </FooterLink>

--- a/web/pageComponents/shared/Header.tsx
+++ b/web/pageComponents/shared/Header.tsx
@@ -130,7 +130,7 @@ const HeadTags = ({ slugs }: { slugs: AllSlugsType }) => {
 const AllSites = () => {
   const allSitesURL = getAllSitesLink('external')
   return (
-    <StyledAllSites href={allSitesURL}>
+    <StyledAllSites href={allSitesURL} prefetch={false}>
       <FormattedMessage id="all_sites" defaultMessage="All Sites" />
     </StyledAllSites>
   )
@@ -172,7 +172,7 @@ const Header = ({ slugs, menuData }: HeaderProps) => {
             >
               {hasSearch && (
                 <ControlChild>
-                  <NextLink href="/search">
+                  <NextLink href="/search" prefetch={false}>
                     <StyledSearchButton variant="ghost_icon" aria-expanded="true" aria-label="Search">
                       <Icon size={24} data={search} />
                     </StyledSearchButton>

--- a/web/pageComponents/shared/Hero/LoopingVideo.tsx
+++ b/web/pageComponents/shared/Hero/LoopingVideo.tsx
@@ -1,9 +1,18 @@
-import { HLSPlayer } from '@components'
+import { HLSPlayer } from '../../../components/src/HLSPlayer'
 import { useSanityLoader } from '../../../lib/hooks/useSanityLoader'
 import styled from 'styled-components'
 import { LoopingVideoData, LoopingVideoRatio } from '../../../types'
+import dynamic from 'next/dynamic'
 
 const DEFAULT_MAX_WIDTH = 1920
+
+const DynamicHLSVideoComponent = dynamic<React.ComponentProps<typeof HLSPlayer>>(
+  () => import('../../../components/src/HLSPlayer').then((mod) => mod.HLSPlayer),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  },
+)
 
 const Container = styled.div<{ $aspectRatio: LoopingVideoRatio }>`
   position: relative;
@@ -27,7 +36,7 @@ const StyledFigure = styled.figure`
   position: absolute;
 `
 
-const StyledHLSPlayer = styled(HLSPlayer)`
+const StyledHLSPlayer = styled(DynamicHLSVideoComponent)`
   position: absolute;
   width: 100%;
   height: 100%;

--- a/web/pageComponents/shared/LocalizationSwitch.tsx
+++ b/web/pageComponents/shared/LocalizationSwitch.tsx
@@ -97,7 +97,7 @@ type LocaleLinkProps = {
 const LocaleLink: React.FC<React.PropsWithChildren<LocaleLinkProps>> = ({ href, title, locale, active, children }) => {
   if (!active) {
     return (
-      <StyledLink href={href} locale={locale} aria-label={title}>
+      <StyledLink href={href} locale={locale} aria-label={title} prefetch={false}>
         {children}
       </StyledLink>
     )

--- a/web/pageComponents/shared/LogoLink.tsx
+++ b/web/pageComponents/shared/LogoLink.tsx
@@ -29,7 +29,7 @@ type LogoLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
 export const LogoLink = ({ ...rest }: LogoLinkProps) => {
   return (
-    <StyledLogoLink href="/" aria-label="Equinor home page" {...rest} className="logo">
+    <StyledLogoLink href="/" aria-label="Equinor home page" {...rest} className="logo" prefetch={false}>
       <AlignedLogoSecondary />
     </StyledLogoLink>
   )

--- a/web/pageComponents/shared/VideoPlayer.tsx
+++ b/web/pageComponents/shared/VideoPlayer.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/media-has-caption */
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 import {
   VideoControlsType,
   VideoPlayerData,
@@ -7,11 +8,20 @@ import {
   VideoType,
   VideoDesignOptionsType,
 } from '../../types/types'
-import { BackgroundContainer, HLSPlayer } from '@components'
+import { BackgroundContainer } from '@components'
 import TitleText from '../shared/portableText/TitleText'
 import { urlFor } from '../../common/helpers'
 import IngressText from './portableText/IngressText'
 import { ButtonLink } from './ButtonLink'
+import { HLSPlayer } from '../../components/src/HLSPlayer'
+
+const DynamicHLSVideoComponent = dynamic<React.ComponentProps<typeof HLSPlayer>>(
+  () => import('../../components/src/HLSPlayer').then((mod) => mod.HLSPlayer),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  },
+)
 
 const StyledHeading = styled(TitleText)`
   padding: 0 0 var(--space-large) 0;
@@ -84,7 +94,7 @@ const ButtonWrapper = styled.div`
   margin-bottom: var(--space-xLarge);
 `
 
-const StyledHLSPlayer = styled(HLSPlayer)`
+const StyledHLSPlayer = styled(DynamicHLSVideoComponent)`
   object-fit: cover;
   width: inherit;
 

--- a/web/pageComponents/topicPages/Breadcrumbs.tsx
+++ b/web/pageComponents/topicPages/Breadcrumbs.tsx
@@ -94,7 +94,9 @@ export const Breadcrumbs = ({
           }
           return (
             <BreadcrumbsListItem key={item.slug}>
-              <StyledNextLink href={item.slug}>{item.label}</StyledNextLink>
+              <StyledNextLink href={item.slug} prefetch={false}>
+                {item.label}
+              </StyledNextLink>
             </BreadcrumbsListItem>
           )
         })}

--- a/web/pageComponents/topicPages/FullWidthVideo.tsx
+++ b/web/pageComponents/topicPages/FullWidthVideo.tsx
@@ -1,6 +1,16 @@
 import { FullWidthVideoData, FullWidthVideoRatio } from '../../types/types'
 import styled from 'styled-components'
-import { BackgroundContainer, HLSPlayer } from '@components'
+import { BackgroundContainer } from '@components'
+import { HLSPlayer } from '../../components/src/HLSPlayer'
+import dynamic from 'next/dynamic'
+
+const DynamicHLSVideoComponent = dynamic<React.ComponentProps<typeof HLSPlayer>>(
+  () => import('../../components/src/HLSPlayer').then((mod) => mod.HLSPlayer),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  },
+)
 
 const Container = styled.div<{ $aspectRatio: FullWidthVideoRatio }>`
   position: relative;
@@ -35,7 +45,7 @@ const StyledFigure = styled.figure`
   position: absolute;
 `
 
-const StyledHLSPlayer = styled(HLSPlayer)`
+const StyledHLSPlayer = styled(DynamicHLSVideoComponent)`
   position: absolute;
   top: 0;
   left: 0;

--- a/web/pages/[[...slug]].tsx
+++ b/web/pages/[[...slug]].tsx
@@ -11,7 +11,7 @@ import { defaultLanguage } from '../languages'
 import Header from '../pageComponents/shared/Header'
 import { FormattedMessage } from 'react-intl'
 import getIntl from '../common/helpers/getIntl'
-import { getRoutePaths } from '../common/helpers/getPaths'
+import { getStaticBuildRoutePaths } from '../common/helpers/getPaths'
 import getPageSlugs from '../common/helpers/getPageSlugs'
 import { getComponentsData } from '../lib/fetchData'
 import { useContext, useEffect } from 'react'
@@ -123,7 +123,8 @@ export const getStaticProps: GetStaticProps = async ({ params, preview = false, 
 }
 
 export const getStaticPaths: GetStaticPaths = async ({ locales = [] }) => {
-  const routePaths = await getRoutePaths(locales)
+  // Not changing getRoutePaths(locales) because its used in sitemap.xml
+  const routePaths = await getStaticBuildRoutePaths(locales)
 
   const paths = routePaths.map((path) => ({
     params: { slug: path.slug },


### PR DESCRIPTION
Try to improve performance by;
- using next optimizePackageImports for packages
- try to dynamic import and use absolute path for tree shaking the heavy third party lib hls.js for video streaming
- set prefetch to false on nextlink to avoid assets loads from all links that would be prefetched in next bundles
- minimize the number of routes to build statically to avoid long builds and get back statically generation