### PR TITLE
Align eventcardcontent #2208

### DIFF
--- a/web/pageComponents/cards/EventsCard.tsx
+++ b/web/pageComponents/cards/EventsCard.tsx
@@ -14,13 +14,14 @@ import { TimeIcon } from '../../components/src/FormattedDateTime/shared'
 import type { EventCardData, EventDateType } from '../../types/types'
 import type { PortableTextBlock } from '@portabletext/types'
 
-const { Text, Media, Action, StyledLandscapeCard } = Card
+const { Text, Media, StyledLandscapeCard } = Card
 
 const StyledCard = styled(Card)`
   height: var(--height);
   /* For the landscape variant, we don't want the title
   column to be too wide*/
   --column-sizes: 40% 1fr;
+  justify-content: space-between;
 `
 
 const StyledMedia = styled(Media)`
@@ -88,9 +89,7 @@ const SmallText = styled.span`
 const ActionContainer = styled.div`
   display: flex;
   gap: var(--space-small);
-  ${StyledLandscapeCard} & {
-    margin-top: var(--space-large);
-  }
+  margin-top: var(--space-large);
 `
 
 const TextInfoWrapper = styled.div``
@@ -112,7 +111,7 @@ const EventsCard = ({ data, hasSectionTitle, orientation = 'portrait', ...rest }
       orientation={orientation}
       style={
         {
-          '--height': 'auto',
+          '--height': '100%',
           '--card-padding': '0 0 var(--space-medium) 0',
         } as CSSProperties
       }
@@ -174,15 +173,8 @@ const EventsCard = ({ data, hasSectionTitle, orientation = 'portrait', ...rest }
             )}
           </Detail>
         </TextInfoWrapper>
-        {orientation === 'landscape' && (
-          <Actions slug={slug} title={plainTitle} location={location} eventDate={eventDate} />
-        )}
+        <Actions slug={slug} title={plainTitle} location={location} eventDate={eventDate} />
       </StyledText>
-      {orientation == 'portrait' && (
-        <Action>
-          <Actions slug={slug} title={plainTitle} location={location} eventDate={eventDate} />
-        </Action>
-      )}
     </StyledCard>
   )
 }


### PR DESCRIPTION
Note, in prod, all three fields are filled, so the gap between the description, place and date and title is not that big as it appears in test
