### PR TITLE
🎨  Alternative active link styling #2317

### DIFF
--- a/web/core/Button/index.tsx
+++ b/web/core/Button/index.tsx
@@ -27,7 +27,7 @@ export const getVariant = (variant: Variants): string => {
       hover:bg-moss-green-60
       focus:outline-none
       focus-visible:envis-outline
-      active:envis-outline
+      active:scale-99
       dark:text-white-100
       dark:hover:bg-white-transparent
       dark:focus-visible:envis-outline-invert
@@ -42,7 +42,7 @@ export const getVariant = (variant: Variants): string => {
       hover:text-white-100
       focus:outline-none
       focus-visible:outline-slate-blue-95
-      active:bg-moss-green-80
+      active:scale-99
       dark:text-white-100
       dark:border-white-100
       dark:hover:bg-white-transparent
@@ -55,7 +55,7 @@ export const getVariant = (variant: Variants): string => {
       hover:bg-moss-green-100
       focus:outline-none
       focus-visible:outline-teal-100
-      active:bg-moss-green-110
+      active:scale-99
       dark:bg-white-100
       dark:hover:bg-moss-green-60
       dark:text-slate-80

--- a/web/core/Link/BaseLink.tsx
+++ b/web/core/Link/BaseLink.tsx
@@ -28,7 +28,7 @@ export const BaseLink = forwardRef<HTMLAnchorElement, BaseLinkProps>(function Ba
     text-slate-80
     focus:outline-none
     focus-visible:envis-outline
-    active:envis-outline
+    active:scale-99
     dark:text-white-100
     dark:focus-visible:envis-outline-invert
     dark:active:envis-outline-invert

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -235,6 +235,9 @@ module.exports = {
         //-lineHeight-3
         planetary: 1.5,
       },
+      scale: {
+        99: '0.99',
+      },
       maxWidth: {
         viewport: '1920px',
       },


### PR DESCRIPTION
Added another active styling instead of using focus-visible styling, just a small scale down transform to indicate "pressed down"