### PR TITLE
🔐 Fixes duplicate key prop warning #3137

### DIFF
--- a/web/sections/teasers/Teaser/Teaser.tsx
+++ b/web/sections/teasers/Teaser/Teaser.tsx
@@ -80,15 +80,14 @@ const Teaser = ({ data, anchor }: TeaserProps) => {
         )}
         {actions && (
           <div className="flex flex-col gap-8">
-            {actions?.map((action) => {
+            {actions?.map((action, idx) => {
               const url = action && getUrlFromAction(action)
-
               return (
                 <ResourceLink
                   href={url as string}
                   {...(action.link?.lang && { locale: getLocaleFromName(action.link?.lang) })}
                   type={action.type}
-                  key={action.id}
+                  key={action.id || idx}
                   variant="fit"
                   extension={action.extension}
                   showExtensionIcon


### PR DESCRIPTION
Ensures a unique key prop is used when rendering action links, resolving a React key prop warning. It uses the index as fallback if the action doesn't have an ID.
