### PR TITLE
Potential fix for code scanning alert no. 44: Server-side request forgery

### DIFF
--- a/web/pages/news/archive/[...pagePath].tsx
+++ b/web/pages/news/archive/[...pagePath].tsx
@@ -203,12 +203,23 @@ export const getStaticProps: GetStaticProps = async ({ preview = false, params, 
   const pagePathArray = params?.pagePath as string[]
   const pagePath = pagePathArray.join('/')
 
+  // Basic path validation to avoid path traversal and unexpected characters
+  if (pagePath.includes('..')) {
+    return { notFound: true }
+  }
+  if (!/^[A-Za-z0-9\/-]+$/.test(pagePath)) {
+    return { notFound: true }
+  }
+
   const archivedItems = archivedNews.filter((e) => e.slug === `/news/archive/${pagePath}`)
   if (archivedItems.length === 0) return { notFound: true }
 
-  const response = await fetchArchiveData(pagePathArray, pagePath, locale)
+  // Derive canonical page path from the archived slug to avoid using raw user input
+  const canonicalPagePath = archivedItems[0].slug.replace(/^\/news\/archive\//, '')
 
-  if (response.status === 404) return fallbackToAnotherLanguage(pagePathArray, pagePath, locale)
+  const response = await fetchArchiveData(pagePathArray, canonicalPagePath, locale)
+
+  if (response.status === 404) return fallbackToAnotherLanguage(pagePathArray, canonicalPagePath, locale)
 
   const pageData = await parseResponse(response)
   const menuQuery = Flags.HAS_FANCY_MENU ? globalMenuQuery : simpleMenuQuery
@@ -227,7 +238,7 @@ export const getStaticProps: GetStaticProps = async ({ preview = false, params, 
         archivedItems,
         news: {
           ...pageData,
-          slug: pagePath,
+          slug: canonicalPagePath,
         },
         intl,
       },


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/energyvision/security/code-scanning/44](https://github.com/equinor/energyvision/security/code-scanning/44)

In general, to fix SSRF risks where user input influences an outgoing request URL, you must (1) ensure the hostname and protocol are not user-controlled, and (2) strictly validate or normalize any user-controlled path components against an allowlist or whitelist of expected patterns before using them in the URL. Any disallowed value should cause the request to be aborted or return `notFound`.

For this specific code, the host is already fixed via `publicRuntimeConfig.archiveStorageURL`, so the remaining work is to constrain `pagePath` before it is passed to `fetchArchiveData`. The project already has an allowlist of valid archived slugs in `archivedNews`. The safest and least intrusive change is:

- Derive a validated `safePagePath` from the `archivedNews` data instead of directly from `params`.
- Reject any `pagePath` that:
  - Contains path traversal (`..` segments).
  - Contains characters outside a safe subset (`a-zA-Z0-9/-`), preventing things like `%2e%2e` and other encodings.
- Use this `safePagePath` consistently everywhere `pagePath` is used for fetching, including in `getStaticProps`, `fetchArchiveData`, and `fallbackToAnotherLanguage`.

Concretely:

1. In `getStaticProps`, after computing `pagePathArray` and `pagePath`, add a validation step:
   - If `pagePath` contains `".."` or disallowed characters, immediately return `{ notFound: true }`.
   - Look up the matching archived item in `archivedNews` and derive the canonical path from that slug: `canonicalPagePath = archivedItem.slug.replace(/^\/news\/archive\//, '')`.
   - Use `canonicalPagePath` (not the raw `pagePath`) for all subsequent calls to `fetchArchiveData` and `fallbackToAnotherLanguage`, and when setting `news.slug` and redirect destinations.
2. Adjust calls:
   - `const response = await fetchArchiveData(pagePathArray, canonicalPagePath, locale)`
   - `if (response.status === 404) return fallbackToAnotherLanguage(pagePathArray, canonicalPagePath, locale)`
3. Update `fallbackToAnotherLanguage`’s redirect to use the validated `pagePath` argument (which is now canonical) – that’s already the case, so no internal change needed there.
4. Keep `fetchArchiveData`’s existing `if (pagePath.includes('.')) return Promise.reject()` as an extra safeguard; it now also receives only a validated string.

This preserves existing functionality (paths that match archived slugs still work and are mapped to the same JSON files) while removing the dependence of the fetch URL path on raw user input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
